### PR TITLE
Bayes fix (plus Poisson support)

### DIFF
--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -21,8 +21,7 @@
 #' package, which is not available on cran. If you wish to use this option, 
 #' you must first install \code{INLA} from \url{http://www.r-inla.org/}.
 #' Note that while \code{bayes = TRUE} currently only supports \code{family} arguments of
-#'  \code{"gaussian"} and \code{"binomial"}, other families will shortly be added. 
-#' For a full list see \code{names(INLA::inla.models()$likelihood)}.
+#'  \code{"gaussian"}, \code{"binomial"}, and \code{"poisson"}, other families will shortly be added. 
 #' @param formula a two-sided linear formula object describing the
 #' mixed-effects of the model; it follows similar syntax as \code{\link[lme4:lmer]{lmer}}.
 #' There are some differences though. First, to specify that a random term should have phylogenetic cov matrix too, 
@@ -45,7 +44,8 @@
 #' reorder rows of the data frame so that species are nested within sites (i.e. arrange first 
 #' by column site then by column sp).
 #' @param family either \code{gaussian} for a Linear Mixed Model, or
-#' \code{binomial} for binary dependent data.
+#' \code{binomial} for binary dependent data. If \code{bayes = TRUE}, \code{poisson} is also
+#' supported.
 #' @param tree a phylogeny for column sp, with "phylo" class.
 #' @param repulsion when nested random term specified, do you want to test repulsion or underdispersion?
 #' Default is FALSE, i.e. test underdispersion.
@@ -667,13 +667,17 @@ communityPGLMM <- function(formula, data = NULL, family = "gaussian", tree, tree
                            marginal.summ = "mean", calc.DIC = FALSE, default.prior = "inla.default", cpp = TRUE,
                            optimizer = c("bobyqa", "Nelder-Mead", "nelder-mead-nlopt", "subplex"), prep.s2.lme4 = FALSE) {
   optimizer = match.arg(optimizer)
-  if ((family %nin% c("gaussian", "binomial"))){
+  if ((family %nin% c("gaussian", "binomial")) & (bayes == FALSE)){
     stop("\nSorry, but only binomial (binary) and gaussian options are available for
          communityPGLMM at this time")
   }
   if(bayes) {
     if (!isTRUE(requireNamespace("INLA", quietly = TRUE))) {
       stop("To run communityPGLMM with bayes = TRUE, you need to install the packages 'INLA'. Please run in your R terminal:\n install.packages('INLA', repos='https://www.math.ntnu.no/inla/R/stable')")
+    }
+    if ((family %nin% c("gaussian", "binomial", "poisson"))){
+      stop("\nSorry, but only binomial (binary), poisson (count), and gaussian options are available for
+         Bayesian communityPGLMM at this time")
     }
   }
   
@@ -709,6 +713,11 @@ communityPGLMM <- function(formula, data = NULL, family = "gaussian", tree, tree
       s2.init <- c(ML.init.z$s2r, ML.init.z$s2n)
       B.init <- ML.init.z$B[ , 1, drop = TRUE]
     }
+  } 
+  
+  if(bayes & ML.init & (family %nin% c("binomial", "gaussian"))) {
+    warning('ML.init option is only available for binomial and gaussian families. You will have to 
+            specify initial values manually if you think the default are problematic.')
   }
   
   if(bayes) {

--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -1708,10 +1708,21 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
   inla_reps <- list()
   
   for(i in seq_along(random.effects)) {
-    inla_effects[[i]] <- as.numeric(as.factor(random.effects[[i]][[2]]))
-    inla_Cmat[[i]] <- solve(random.effects[[i]][[3]])
-    inla_weights[[i]] <- random.effects[[i]][[1]]
-    if(length(random.effects[[i]]) == 4) {
+    if(length(random.effects[[i]]) == 1) {
+      inla_effects[[i]] <- 1:nrow(data)
+      inla_Cmat[[i]] <- solve(random.effects[[i]][[1]])
+    } else if(length(random.effects[[i]]) == 2) {
+      inla_effects[[i]] <- 1:nrow(data)
+      inla_weights[[i]] <- random.effects[[i]][1]
+      inla_Cmat[[i]] <- solve(random.effects[[i]][[2]])
+    } else if(length(random.effects[[i]]) == 3) {
+      inla_effects[[i]] <- as.numeric(as.factor(random.effects[[i]][[2]]))
+      inla_Cmat[[i]] <- solve(random.effects[[i]][[3]])
+      inla_weights[[i]] <- random.effects[[i]][[1]]
+    } else {
+      inla_effects[[i]] <- as.numeric(as.factor(random.effects[[i]][[2]]))
+      inla_Cmat[[i]] <- solve(random.effects[[i]][[3]])
+      inla_weights[[i]] <- random.effects[[i]][[1]]
       inla_reps[[i]] <- as.numeric(as.factor(random.effects[[i]][[4]]))
     }
   }
@@ -1736,6 +1747,12 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
               f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], replicate = inla_reps[[", i, "]], initial = s2.init[", i, "])")
               inla_formula <- paste(inla_formula, f_form, sep = " + ")
             }
+          } else if(length(random.effects[[i]]) == 1) {
+            f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "])")
+            inla_formula <- paste(inla_formula, f_form, sep = " + ")
+          } else {
+            f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "])")
+            inla_formula <- paste(inla_formula, f_form, sep = " + ")
           }
         }
       }
@@ -1758,6 +1775,12 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
               f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], replicate = inla_reps[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
               inla_formula <- paste(inla_formula, f_form, sep = " + ")
             }
+          } else if(length(random.effects[[i]]) == 1) {
+            f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
+            inla_formula <- paste(inla_formula, f_form, sep = " + ")
+          } else {
+            f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
+            inla_formula <- paste(inla_formula, f_form, sep = " + ")
           }
         }
       }
@@ -1782,6 +1805,12 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
               f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], replicate = inla_reps[[", i, "]], initial = s2.init[", i, "])")
               inla_formula <- paste(inla_formula, f_form, sep = " + ")
             }
+          } else if(length(random.effects[[i]]) == 1) {
+            f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "])")
+            inla_formula <- paste(inla_formula, f_form, sep = " + ")
+          } else {
+            f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "])")
+            inla_formula <- paste(inla_formula, f_form, sep = " + ")
           }
         }
       }
@@ -1804,6 +1833,12 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
               f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], replicate = inla_reps[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
               inla_formula <- paste(inla_formula, f_form, sep = " + ")
             }
+          } else if(length(random.effects[[i]]) == 1) {
+            f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
+            inla_formula <- paste(inla_formula, f_form, sep = " + ")
+          } else {
+            f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
+            inla_formula <- paste(inla_formula, f_form, sep = " + ")
           }
         }
       }
@@ -1856,7 +1891,7 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
     marginal.summ <- "0.5quant"
   }
   
-  nested <- sapply(random.effects, length) == 4
+  nested <- sapply(random.effects, length) %in% c(1, 2, 4)
   
   variances <- 1/out$summary.hyperpar[ , marginal.summ]
   variances.ci <- 1/out$summary.hyperpar[ , c("0.975quant", "0.025quant")]

--- a/tests/testthat/test-pglmm.R
+++ b/tests/testthat/test-pglmm.R
@@ -27,16 +27,21 @@ expect_equivalent(test2_binary_cpp, test2_binary_r)
 ## test bayesian models
 test1_gaussian_bayes  = phyr::communityPGLMM(freq ~ 1 + shade + (1|sp__) + (1|site) + (1|sp__@site), 
                                          dat, tree = phylotree, REML = F, bayes = TRUE)
-# test1_gaussian_bayes_noreml  = phyr::communityPGLMM(freq ~ 1 + shade + (1|sp__) + (1|site) + (1|sp@site), 
-#                                                   dat, tree = phylotree, REML = F, bayes = TRUE,
-#                                                   ML.init = FALSE)
+                                           
 
 test1_binomial_bayes  = phyr::communityPGLMM(pa ~ 1 + shade + (1|sp__) + (1|site) + (1|sp__@site), 
                                                   dat, tree = phylotree, REML = F, bayes = TRUE,
                                                   ML.init = FALSE, family = "binomial")
-# test1_binomial_bayes_noreml  = phyr::communityPGLMM(pa ~ 1 + shade + (1|sp__) + (1|site) + (1|sp@site), 
-#                                                     dat, tree = phylotree, REML = F, bayes = TRUE,
-#                                                     ML.init = FALSE, family = "binomial")
+
+test1_poisson_bayes  = phyr::communityPGLMM(freq ~ 1 + shade + (1|sp__) + (1|site) + (1|sp__@site), 
+                                             dat, tree = phylotree, REML = F, bayes = TRUE,
+                                             ML.init = FALSE, family = "poisson")
+## try a 'overdispersed' Poisson (e.g. add row random effect to account for variance in the lambda values)
+test1_poisson_bayes_overdispersed  = phyr::communityPGLMM(freq ~ 1 + shade + (1|sp__) + (1|site) + (1|sp__@site) + (1|sp@site), 
+                                            dat, tree = phylotree, REML = F, bayes = TRUE,
+                                            ML.init = FALSE, family = "poisson")
+
+
 
 test_that("Bayesian communityPGLMM produced correct object", {
   expect_is(test1_gaussian_bayes, "communityPGLMM")

--- a/tests/testthat/test-pglmm.R
+++ b/tests/testthat/test-pglmm.R
@@ -174,3 +174,14 @@ tree_site = ape::rtree(n = n_distinct(dat$site), tip.label = sort(unique(dat$sit
 z_bipartite = phyr::communityPGLMM(freq ~ 1 + shade + (1|sp__) + (1|site__) + 
                                      (1|sp__@site) + (1|sp@site__) + (1|sp__@site__), 
                     data = dat, family = "gaussian", tree = phylotree, tree_site = tree_site, REML = TRUE)
+
+z_bipartite_bayes = phyr::communityPGLMM(freq ~ 1 + shade + (1|sp__) + (1|site__) + 
+                                     (1|sp__@site) + (1|sp@site__) + (1|sp__@site__), 
+                                   data = dat, family = "gaussian", tree = phylotree, tree_site = tree_site, 
+                                   bayes = TRUE, ML.init = TRUE)
+
+z_bipartite_bayes_2 = phyr::communityPGLMM(freq ~ 1 + shade + (1|sp__) + (1|site__) + 
+                                           (1|sp__@site) + (1|sp@site__) + (1|sp__@site__), 
+                                         data = dat, family = "gaussian", tree = phylotree, tree_site = tree_site, 
+                                         bayes = TRUE, ML.init = FALSE, default.prior = "pc.prior")
+


### PR DESCRIPTION
Hi Daijiang,

I've fixed the Bayesian implementation to work with the new bipartite syntax and `random.effects` object. You may have noticed I also allowed for a new type of element in the `random.effects` with length 2. This is just so it is possible to specify a 'random slopes' (or as I prefer, 'random weights') model with a custom full covariance matrix. In this case the user can put the covariate in the first slot, and the sparse matrix in the second. This is mostly for my own purposes at the moment, it shouldn't effect anything else, and probably shouldn't be exposed to the user at the moment because I haven't done any tests yet.

While I was at it, I added support for the Poisson family to the Bayesian version, because this is the easiest family (no extra parameters). It is possible to do an 'over-dispersed' Poisson model by adding an `(1|row_id)` random effect, where `row_id` is a unique id for each row in the data. This can alternatively be accomplished by adding `(1|sp@site)` to the formula, avoiding the need to add a new row id column to the data. I think I'll next add negative binomial, and then a zero-inflated Poisson, which will be the most challenging, but I think will also increase the generality of the model for ecological data the most.

I also want to submit some `ggplot2` based plotting functions. Just wanted to check you are okay with this? I'll have to add `ggplot2` (and possibly some `ggplot2` extension packages, such as `ggtree`) to the Imports.

Cheers,
Russell