### PR TITLE
Bayes update

### DIFF
--- a/R/pglmm-utils.R
+++ b/R/pglmm-utils.R
@@ -781,18 +781,13 @@ summary.communityPGLMM <- function(object, digits = max(3, getOption("digits") -
   
   if(x$bayes) {
     if (x$family == "gaussian") {
-      if (x$REML == TRUE) {
-        cat("Linear mixed model fit by Bayesian INLA with contrained variances")
-      } else {
-        cat("Linear mixed model fit by Bayesian INLA")
-      }
+      cat("Linear mixed model fit by Bayesian INLA")
     }
     if (x$family == "binomial") {
-      if (x$REML == TRUE) {
-        cat("Generalized linear mixed model fit by Bayesian INLA with contrained variances")
-      } else {
-        cat("Generalized linear mixed model fit by Bayesian INLA")
-      }
+      cat("Generalized linear mixed model for binomial data fit by Bayesian INLA")
+    }
+    if (x$family == "poisson") {
+      cat("Generalized linear mixed model for poisson data fit by Bayesian INLA")
     }
   } else {
     if (x$family == "gaussian") {

--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -150,10 +150,7 @@
 #' @param REML Whether REML or ML is used for model fitting. For the
 #'   generalized linear mixed model for binary data, these don't have
 #'   standard interpretations, and there is no log likelihood function
-#'   that can be used in likelihood ratio tests. If \code{bayes = TRUE},
-#'   \code{REML = TRUE} will place a sum to one constraint on the random
-#'   effects, which should produce more comparable results to a REML analysis
-#'   in a maximum likelihood context.
+#'   that can be used in likelihood ratio tests. Ignored if \code{bayes = TRUE}
 #' @param bayes Whether to fit a Bayesian version of the PGLMM using \code{r-inla}.
 #' @param s2.init An array of initial estimates of s2 for each random
 #'   effect that scales the variance. If s2.init is not provided for
@@ -195,15 +192,22 @@
 #' @param marginal.summ Summary statistic to use for the estimate of coefficients when
 #'   doing a Bayesian PGLMM (when \code{bayes = TRUE}). Options are: "mean",
 #'   "median", or "mode", referring to different characterizations of the central
-#'   tendency of the bayesian posterior marginal distributions. Ignored if \code{bayes == FALSE}
+#'   tendency of the bayesian posterior marginal distributions. Ignored if \code{bayes = FALSE}
 #' @param calc.DIC Should the Deviance Informatiob Criterion be calculated and returned,
 #'   when doing a bayesian PGLMM? Ignored if \code{bayes = FALSE}
 #' @param default.prior Which type of default prior should be used by \code{communityPGLMM}?
-#'   Only used if \code{bayes = TRUE}, ignored otherwise. There are currently two options:
-#'   "inla.default", which uses the default \code{INLA} priors, or "pc.prior", which uses a
+#'   Only used if \code{bayes = TRUE}, ignored otherwise. There are currently four options:
+#'   "inla.default", which uses the default \code{INLA} priors; "pc.prior.auto", which uses a
 #'   complexity penalizing prior (as described in 
-#'   \href{https://arxiv.org/abs/1403.4630v3}{Simpson et al. (2017)}).
-#'   "pc.prior" is only implemented for \code{family = "gaussian"} currently.
+#'   \href{https://arxiv.org/abs/1403.4630v3}{Simpson et al. (2017)}), which tries to automatically 
+#'   choose good parameters (only available for gaussian and binomial responses); "pc.prior", which 
+#'   allows the user to set custom parameters on the "pc.prior" prior, using the \code{prior_alpha} 
+#'   and \code{prior_mu} parameters (Run \code{INLA::inla.doc("pc.prec")} for details on these 
+#'   parameters); and "uninformative", which sets a very uniformative prior 
+#'   (nearly uniform) by using a very flat exponential distribution. This last one is generally
+#'   not recommended but may in some cases give estimates closer to the maximum likelihood estimates.
+#'   "pc.prior.auto" is only implemented for \code{family = "gaussian"} and \code{family = "binomial"} 
+#'   currently.
 #' @param cpp Whether to use c++ function for optim. Default is TRUE. Ignored if \code{bayes = TRUE}.
 #' @param optimizer nelder-mead-nlopt (default) or bobyqa or Nelder-Mead or subplex. 
 #' Nelder-Mead is from the stats package and the other ones are from the nloptr package.
@@ -213,6 +217,14 @@
 #' @param add.obs.re Wether add observation-level random term for poisson and binomial
 #'   distributions? Normally it would be a good idea to add this to account for overdispersions.
 #'   Thus, we set it to TRUE by default.
+#' @param prior_alpha Only used if \code{bayes = TRUE} and \code{default.prior == "pc.prior"}, in
+#'   which case it sets the alpha parameter of \code{INLA}'s complexity penalizing prior for the 
+#'   random effects.The prior is an exponential distribution where prob(sd > mu) = alpha, 
+#'   where sd is the standard deviation of the random effect.
+#' @param prior_mu Only used if \code{bayes = TRUE} and \code{default.prior == "pc.prior"}, in
+#'   which case it sets the mu parameter of \code{INLA}'s complexity penalizing prior for the 
+#'   random effects.The prior is an exponential distribution where prob(sd > mu) = alpha, 
+#'   where sd is the standard deviation of the random effect.
 #' @return An object (list) of class \code{communityPGLMM} with the following elements:
 #' \item{formula}{the formula for fixed effects}
 #' \item{formula_original}{the formula for both fixed effects and random effects}
@@ -548,9 +560,11 @@ communityPGLMM <- function(formula, data = NULL, family = "gaussian", tree = NUL
                               sp = sp, site = site, 
                               random.effects = random.effects, 
                               s2.init = s2.init, B.init = B.init, 
-                              verbose = verbose, REML = REML,
+                              verbose = verbose, 
                               marginal.summ = marginal.summ, calc.DIC = calc.DIC, 
-                              default.prior = default.prior)
+                              default.prior = default.prior, 
+                              prior_alpha = prior_alpha, 
+                              prior_mu = prior_mu)
   } else {# max likelihood 
     if (family == "gaussian") {
       z <- communityPGLMM.gaussian(formula = formula, data = data, 
@@ -870,9 +884,10 @@ communityPGLMM.glmm <- function(formula, data = list(), family = "binomial",
 communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian", 
                                  sp = NULL, site = NULL, random.effects = list(), 
                                  s2.init = NULL, B.init = NULL, 
-                                 verbose = FALSE, REML = FALSE,
+                                 verbose = FALSE, 
                                  marginal.summ = "mean", calc.DIC = FALSE, 
-                                 default.prior = "inla.default") {
+                                 default.prior = "inla.default",
+                                 prior_alpha = 1, prior_mu = 0.1) {
   mf <- model.frame(formula = formula, data = data, na.action = NULL)
   X <- model.matrix(attr(mf, "terms"), data = mf)
   Y <- model.response(mf)
@@ -905,7 +920,7 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
     s2.init <- s2.init[-q]
   }
   
-  if(default.prior == "pc.prior") {
+  if(default.prior == "pc.prior.auto") {
     if(family == "gaussian") {
       lmod <- lm(formula, data)
       sdres <- sd(residuals(lmod))
@@ -914,12 +929,20 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
       if(family == "binomial") {
         lmod <- glm(formula, data = data, family = "binomial")
         sdres <- sd(lmod$y - lmod$fitted.values)
-        pcprior <- list(prec = list(prior="pc.prec", param = c(1, 0.01)))
+        pcprior <- list(prec = list(prior="pc.prec", param = c(1, 0.1)))
       } else {
-        warning("pc.prior not yet implemented for this family. switching to default INLA prior...")
+        warning("pc.prior.auto not yet implemented for this family. switching to default INLA prior...")
         default.prior <- "inla.default"
       }
     }
+  } 
+    
+  if(default.prior == "pc.prior") {
+    pcprior <- list(prec = list(prior="pc.prec", param = c(prior_mu, prior_alpha)))
+  }
+  
+  if(default.prior == "uninformative") {
+    pcprior <- list(prec = list(prior="pc.prec", param = c(100, 0.99))) ## very flat prior, generally not recommended!
   }
   
   # contruct INLA formula
@@ -953,22 +976,22 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
     for(i in seq_along(random.effects)) {
       if(length(random.effects[[i]]) == 3) { # non-nested term
         if(length(random.effects[[i]][[1]]) == 1) {
-          f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "])")
+          f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "])")
         } else {
-          f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "])")
+          f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "])")
         }
       } else { # nested term
         if(length(random.effects[[i]]) == 4) { 
           if(length(random.effects[[i]][[1]]) == 1) {
-            f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], replicate = inla_reps[[", i, "]], initial = s2.init[", i, "])")
+            f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], replicate = inla_reps[[", i, "]], initial = s2.init[", i, "])")
           } else {
-            f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], replicate = inla_reps[[", i, "]], initial = s2.init[", i, "])")
+            f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], replicate = inla_reps[[", i, "]], initial = s2.init[", i, "])")
           }
         } else {
           if(length(random.effects[[i]]) == 1) {
-            f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "])")
+            f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "])")
           } else {
-            f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "])")
+            f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "])")
           }
         }
       }
@@ -978,29 +1001,25 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
     for(i in seq_along(random.effects)) {
       if(length(random.effects[[i]]) == 3) { # non-nested term
         if(length(random.effects[[i]][[1]]) == 1) {
-          f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
+          f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
         } else {
-          f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
+          f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
         }
       } else { # nested term
         if(length(random.effects[[i]]) == 4) {
           if(length(random.effects[[i]][[1]]) == 1) {
-            f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], replicate = inla_reps[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
+            f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], replicate = inla_reps[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
           } else {
-            f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], replicate = inla_reps[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
+            f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], replicate = inla_reps[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
           }
         } else if(length(random.effects[[i]]) == 1) {
-          f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
+          f_form <- paste0("f(inla_effects[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
         } else {
-          f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = FALSE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
+          f_form <- paste0("f(inla_effects[[", i, "]], inla_weights[[", i, "]], model = 'generic0', constr = TRUE, Cmatrix = inla_Cmat[[", i, "]], initial = s2.init[", i, "], hyper = pcprior)")
         }
       }
       inla_formula <- paste(inla_formula, f_form, sep = " + ")
     }
-  }
-  
-  if(REML){
-    inla_formula <- gsub(pattern = "constr = FALSE", replacement = "constr = TRUE", inla_formula)
   }
   
   if(family == "gaussian") {

--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -1095,7 +1095,7 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
                   s2resid = resid_var, s2n.ci = variances.ci[nested, ], 
                   s2r.ci = variances.ci[!nested, ], s2resid.ci = resid_var.ci,
                   logLik = out$mlik[1, 1], AIC = NULL, BIC = NULL, DIC = DIC, 
-                  REML = REML, bayes = TRUE, marginal.summ = marginal.summ, 
+                  REML = NULL, bayes = TRUE, marginal.summ = marginal.summ, 
                   s2.init = s2.init, B.init = B.init, Y = Y, X = X, H = H, 
                   iV = NULL, mu = NULL, nested = nested, sp = sp, site = site, Zt = NULL, St = NULL, 
                   convcode = NULL, niter = NULL, inla.model = out)

--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -486,7 +486,7 @@ communityPGLMM <- function(formula, data = NULL, family = "gaussian", tree = NUL
                            maxit = 500, tol.pql = 10^-6, maxit.pql = 200, verbose = FALSE, ML.init = TRUE, 
                            marginal.summ = "mean", calc.DIC = FALSE, default.prior = "inla.default", cpp = TRUE,
                            optimizer = c("nelder-mead-nlopt", "bobyqa", "Nelder-Mead", "subplex"), prep.s2.lme4 = FALSE,
-                           add.obs.re = TRUE) {
+                           add.obs.re = TRUE, prior_alpha = 0.1, prior_mu = 1) {
   
   optimizer = match.arg(optimizer)
   if ((family %nin% c("gaussian", "binomial", "poisson")) & (bayes == FALSE)){

--- a/tests/testthat/test-pglmm.R
+++ b/tests/testthat/test-pglmm.R
@@ -69,12 +69,12 @@ test_that("ignore these tests when on CRAN since they are time consuming", {
                                                                                  site) + (1 | sp__@site), dat, tree = phylotree, bayes = TRUE)
   
   test1_binomial_bayes = phyr::communityPGLMM(pa ~ 1 + shade + (1 | sp__) + (1 | site) + 
-                                                (1 | sp__@site), dat, tree = phylotree, ML.init = FALSE, 
-                                              family = "binomial")
+                                                (1 | sp__@site), dat, tree = phylotree, ML.init = FALSE, bayes = TRUE,
+                                              family = "binomial", default.prior = "pc.prior.auto")
   
   test1_poisson_bayes = phyr::communityPGLMM(freq ~ 1 + shade + (1 | sp__) + (1 | site) + 
                                                (1 | sp__@site), dat, tree = phylotree, bayes = TRUE, ML.init = FALSE, 
-                                             family = "poisson")
+                                             family = "poisson", default.prior = "pc.prior.auto")
   
   ## try a 'overdispersed' Poisson (e.g. add row random effect to account for
   ## variance in the lambda values)

--- a/tests/testthat/test-pglmm.R
+++ b/tests/testthat/test-pglmm.R
@@ -66,7 +66,8 @@ test_that("ignore these tests when on CRAN since they are time consuming", {
                                         optimizer = "Nelder-Mead")
   
   test1_gaussian_bayes = phyr::communityPGLMM(freq ~ 1 + shade + (1 | sp__) + (1 | 
-                                                                                 site) + (1 | sp__@site), dat, tree = phylotree, bayes = TRUE)
+                                                                                 site) + (1 | sp__@site), dat, tree = phylotree, bayes = TRUE,
+                                              default.prior = "pc.prior.default")
   
   test1_binomial_bayes = phyr::communityPGLMM(pa ~ 1 + shade + (1 | sp__) + (1 | site) + 
                                                 (1 | sp__@site), dat, tree = phylotree, ML.init = FALSE, bayes = TRUE,
@@ -74,7 +75,8 @@ test_that("ignore these tests when on CRAN since they are time consuming", {
   
   test1_poisson_bayes = phyr::communityPGLMM(freq ~ 1 + shade + (1 | sp__) + (1 | site) + 
                                                (1 | sp__@site), dat, tree = phylotree, bayes = TRUE, ML.init = FALSE, 
-                                             family = "poisson", default.prior = "pc.prior")
+                                             family = "poisson", default.prior = "pc.prior",
+                                             prior_alpha = 0.01, prior_mu = 1)
   
   ## try a 'overdispersed' Poisson (e.g. add row random effect to account for
   ## variance in the lambda values)

--- a/tests/testthat/test-pglmm.R
+++ b/tests/testthat/test-pglmm.R
@@ -66,21 +66,21 @@ test_that("ignore these tests when on CRAN since they are time consuming", {
                                         optimizer = "Nelder-Mead")
   
   test1_gaussian_bayes = phyr::communityPGLMM(freq ~ 1 + shade + (1 | sp__) + (1 | 
-                                                                                 site) + (1 | sp__@site), dat, tree = phylotree, REML = F, bayes = TRUE)
+                                                                                 site) + (1 | sp__@site), dat, tree = phylotree, bayes = TRUE)
   
   test1_binomial_bayes = phyr::communityPGLMM(pa ~ 1 + shade + (1 | sp__) + (1 | site) + 
-                                                (1 | sp__@site), dat, tree = phylotree, REML = F, bayes = TRUE, ML.init = FALSE, 
+                                                (1 | sp__@site), dat, tree = phylotree, ML.init = FALSE, 
                                               family = "binomial")
   
   test1_poisson_bayes = phyr::communityPGLMM(freq ~ 1 + shade + (1 | sp__) + (1 | site) + 
-                                               (1 | sp__@site), dat, tree = phylotree, REML = F, bayes = TRUE, ML.init = FALSE, 
+                                               (1 | sp__@site), dat, tree = phylotree, bayes = TRUE, ML.init = FALSE, 
                                              family = "poisson")
   
   ## try a 'overdispersed' Poisson (e.g. add row random effect to account for
   ## variance in the lambda values)
   test1_poisson_bayes_overdispersed = phyr::communityPGLMM(freq ~ 1 + shade + (1 | 
                                                                                  sp__) + (1 | site) + (1 | sp__@site) + (1 | sp@site), dat, tree = phylotree, 
-                                                           REML = F, bayes = TRUE, ML.init = FALSE, family = "poisson")
+                                                           bayes = TRUE, ML.init = FALSE, family = "poisson")
   
   test_that("cpp and r version phyr gave the same results: gaussian", {
     expect_equivalent(test1_gaussian_cpp, test1_gaussian_r)
@@ -226,7 +226,7 @@ test_that("ignore these tests when on CRAN since they are time consuming", {
   
   z_bipartite_bayes_2 = phyr::communityPGLMM(freq ~ 1 + shade + (1 | sp__) + (1 | site__) + 
                                                (1 | sp__@site) + (1 | sp@site__) + (1 | sp__@site__), data = dat, family = "gaussian", 
-                                             tree = phylotree, tree_site = tree_site, bayes = TRUE, ML.init = FALSE, default.prior = "pc.prior")
+                                             tree = phylotree, tree_site = tree_site, bayes = TRUE, ML.init = FALSE, default.prior = "pc.prior.auto")
   
   # # test tree and tree_site as cov matrix
   # test_that("testing tree and tree_site as cov matrix", {

--- a/tests/testthat/test-pglmm.R
+++ b/tests/testthat/test-pglmm.R
@@ -70,11 +70,11 @@ test_that("ignore these tests when on CRAN since they are time consuming", {
   
   test1_binomial_bayes = phyr::communityPGLMM(pa ~ 1 + shade + (1 | sp__) + (1 | site) + 
                                                 (1 | sp__@site), dat, tree = phylotree, ML.init = FALSE, bayes = TRUE,
-                                              family = "binomial", default.prior = "pc.prior.auto")
+                                              family = "binomial", default.prior = "uninformative")
   
   test1_poisson_bayes = phyr::communityPGLMM(freq ~ 1 + shade + (1 | sp__) + (1 | site) + 
                                                (1 | sp__@site), dat, tree = phylotree, bayes = TRUE, ML.init = FALSE, 
-                                             family = "poisson", default.prior = "pc.prior.auto")
+                                             family = "poisson", default.prior = "pc.prior")
   
   ## try a 'overdispersed' Poisson (e.g. add row random effect to account for
   ## variance in the lambda values)


### PR DESCRIPTION
Hi Daijiang,

Just made a few changes to the Bayesian communityPGLMM I've been meaning to do for awhile. I've removed the REML option because I decided it just doesn't make sense in a Bayesian context, and I believe that the sum to zero constraint should generally be enforced in the model (unless the intercept is suppressed, but I assume that will rarely happen, maybe I should add a warning if the intercept is removed, the model might not be valid?) I also added a few more options for the prior. Overall, it is pretty minor changes. With this change, I believe the Bayesian version will tend to produce results most similar to the REML models. But we can explore this more with simulation. Speaking of which, do you have any timeline for getting started on a paper for `phyr`? We should probably discuss how to divide up the work load for that at some point.

Cheers,
Russell