### PR TITLE
Fix binomial plus zerinfl

### DIFF
--- a/R/pglmm-utils.R
+++ b/R/pglmm-utils.R
@@ -849,7 +849,7 @@ summary.communityPGLMM <- function(object, digits = max(3, getOption("digits") -
   
   if(grepl("zeroinflated", x$family)) {
     cat("\nZero Inflation Paramater:\n")
-    print(data.frame(Estimate = x$zi, lower.CI = x$zi.ci[1], upper.CI = x$zi.ci[2]), digits = digits)
+    print(data.frame(Estimate = x$zi, lower.CI = x$zi.ci[1, 1], upper.CI = x$zi.ci[1, 2]), digits = digits)
   }
   
   cat("\nRandom effects:\n")
@@ -1025,10 +1025,14 @@ residuals.communityPGLMM <- function(
 #' @return Fitted values. For binomial and poisson PGLMMs, this is equal to mu.
 #' @export
 fitted.communityPGLMM <- function(object, ...){
-  if(object$family %in% c("binomial","poisson")){
-    ft = object$mu[, 1]
-  } else {
+  if(object$bayes) {
     ft = communityPGLMM.predicted.values(object)$Y_hat
+  } else {
+    if(object$family %in% c("binomial","poisson")){
+      ft = object$mu[, 1]
+    } else {
+      ft = communityPGLMM.predicted.values(object)$Y_hat
+    }
   }
   
   ft

--- a/R/pglmm-utils.R
+++ b/R/pglmm-utils.R
@@ -848,7 +848,7 @@ summary.communityPGLMM <- function(object, digits = max(3, getOption("digits") -
   }
   
   if(grepl("zeroinflated", x$family)) {
-    cat("\nZero Inflation Paramater:\n")
+    cat("\nZero Inflation Parameter:\n")
     print(data.frame(Estimate = x$zi, lower.CI = x$zi.ci[1, 1], upper.CI = x$zi.ci[1, 2]), digits = digits)
   }
   

--- a/R/pglmm-utils.R
+++ b/R/pglmm-utils.R
@@ -849,7 +849,7 @@ summary.communityPGLMM <- function(object, digits = max(3, getOption("digits") -
   
   if(grepl("zeroinflated", x$family)) {
     cat("\nZero Inflation Paramater:\n")
-    print(c(Estimate = x$zi, lower.CI = x$zi.ci[1], upper.CI = x$zi.ci[2]), digits = digits)
+    print(data.frame(Estimate = x$zi, lower.CI = x$zi.ci[1], upper.CI = x$zi.ci[2]), digits = digits)
   }
   
   cat("\nRandom effects:\n")

--- a/R/pglmm-utils.R
+++ b/R/pglmm-utils.R
@@ -790,6 +790,12 @@ summary.communityPGLMM <- function(object, digits = max(3, getOption("digits") -
     if (x$family == "poisson") {
       cat("Generalized linear mixed model for poisson data fit by Bayesian INLA")
     }
+    if (x$family == "zeroinflated.binomial") {
+      cat("Generalized linear mixed model for binomial data with zero inflation fit by Bayesian INLA")
+    }
+    if (x$family == "zeroinflated.poisson") {
+      cat("Generalized linear mixed model for poisson data with zero inflation fit by Bayesian INLA")
+    }
   } else {
     if (x$family == "gaussian") {
       if (x$REML == TRUE) {
@@ -839,6 +845,11 @@ summary.communityPGLMM <- function(object, digits = max(3, getOption("digits") -
       names(BIC) = "BIC"
       print(c(logLik, AIC, BIC), digits = digits)
     }
+  }
+  
+  if(grepl("zeroinflated", x$family)) {
+    cat("\nZero Inflation Paramater:\n")
+    print(c(Estimate = x$zi, lower.CI = x$zi.ci[1], upper.CI = x$zi.ci[2]), digits = digits)
   }
   
   cat("\nRandom effects:\n")

--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -922,6 +922,8 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
   n <- nrow(X)
   q <- length(random.effects)
   
+  base_family <- gsub("zeroinflated.", "", family, fixed = TRUE)
+  
   if(family == "zeroinflated.binomial") {
     family <- "zeroinflatedbinomial1"
   }
@@ -950,7 +952,6 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
     if (!is.null(B.init) & length(B.init) != p) {
       warning("B.init not correct length, so computed B.init using glm()")
     }
-    base_family <- gsub("zeroinflated.", "", family, fixed = TRUE)
     if(base_family == "binomial" & !is.null(Ntrials)) {
       resp <- all.vars(update(formula, .~0)) 
       formula_glm <- update.formula(formula, as.formula(paste0("cbind(", resp, ", Ntrials - ", resp ,") ~ .")))

--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -525,7 +525,7 @@ communityPGLMM <- function(formula, data = NULL, family = "gaussian", tree = NUL
   prep_re = if(is.null(random.effects)) TRUE else FALSE
   if(prep_re) {
     dat_prepared = prep_dat_pglmm(formula, data, tree, repulsion, prep_re, family, 
-                                  prep.s2.lme4, tree_site, bayes, add.obs.re)
+                                  prep.s2.lme4, tree_site, bayes = FALSE, add.obs.re)
     formula = dat_prepared$formula
     data = dat_prepared$data
     sp = dat_prepared$sp 

--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -960,7 +960,7 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
       data_glm <- data
     }
     if ((is.null(B.init) | (!is.null(B.init) & length(B.init) != p))) {
-      B.init <- t(matrix(glm(formula = formula_glm, data = data, family = family, na.action = na.omit)$coefficients, ncol = p))
+      B.init <- t(matrix(glm(formula = formula_glm, data = data_glm, family = family, na.action = na.omit)$coefficients, ncol = p))
     } else {
       B.init <- matrix(B.init, ncol = 1)
     }

--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -558,10 +558,13 @@ communityPGLMM <- function(formula, data = NULL, family = "gaussian", tree = NUL
       if(family == "binomial" & !is.null(Ntrials)) {
         resp <- all.vars(update(formula, .~0)) 
         formula_glm <- update.formula(formula, as.formula(paste0("cbind(", resp, ", Ntrials - ", resp ,") ~ .")))
+        data_glm <- data
+        data_glm$Ntrials = Ntrials
       } else {
         formula_glm <- formula
+        data_glm <- data
       }
-      ML.init.z <- communityPGLMM.glmm(formula = formula_glm, data = data, 
+      ML.init.z <- communityPGLMM.glmm(formula = formula_glm, data = data_glm, 
                                          sp = sp, site = site, family = family,
                                          random.effects = random.effects, REML = REML, 
                                          s2.init = s2.init, B.init = B.init, reltol = reltol, 

--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -1131,9 +1131,9 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
   }
   
   if(grepl("zeroinflated", family)) {
-    zeroinlated_param <- variances[1]
+    zeroinlated_param <- 1/variances[1]
     variances <- variances[-1]
-    zeroinflated_param.ci <- variances.ci[1, ]
+    zeroinflated_param.ci <- 1/variances.ci[1, ]
     variances.ci <- variances.ci[-1, ]
   } else {
     zeroinlated_param <- NULL

--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -953,8 +953,11 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
     if(family == "binomial" & !is.null(Ntrials)) {
       resp <- all.vars(update(formula, .~0)) 
       formula_glm <- update.formula(formula, as.formula(paste0("cbind(", resp, ", Ntrials - ", resp ,") ~ .")))
+      data_glm <- data
+      data_glm$Ntrials = Ntrials
     } else {
       formula_glm <- formula
+      data_glm <- data
     }
     if ((is.null(B.init) | (!is.null(B.init) & length(B.init) != p))) {
       B.init <- t(matrix(glm(formula = formula_glm, data = data, family = family, na.action = na.omit)$coefficients, ncol = p))

--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -950,7 +950,8 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
     if (!is.null(B.init) & length(B.init) != p) {
       warning("B.init not correct length, so computed B.init using glm()")
     }
-    if(family == "binomial" & !is.null(Ntrials)) {
+    base_family <- gsub("zeroinflated.", "", family, fixed = TRUE)
+    if(base_family == "binomial" & !is.null(Ntrials)) {
       resp <- all.vars(update(formula, .~0)) 
       formula_glm <- update.formula(formula, as.formula(paste0("cbind(", resp, ", Ntrials - ", resp ,") ~ .")))
       data_glm <- data
@@ -960,7 +961,7 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
       data_glm <- data
     }
     if ((is.null(B.init) | (!is.null(B.init) & length(B.init) != p))) {
-      B.init <- t(matrix(glm(formula = formula_glm, data = data_glm, family = family, na.action = na.omit)$coefficients, ncol = p))
+      B.init <- t(matrix(glm(formula = formula_glm, data = data_glm, family = base_family, na.action = na.omit)$coefficients, ncol = p))
     } else {
       B.init <- matrix(B.init, ncol = 1)
     }

--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -592,9 +592,22 @@ communityPGLMM <- function(formula, data = NULL, family = "gaussian", tree = NUL
                                    verbose = verbose, cpp = cpp, optimizer = optimizer)
     }
     
-    if (family %in% c("binomial", "poisson")) {
+    if (family == "poisson") {
       if (is.null(s2.init)) s2.init <- 0.25
       z <- communityPGLMM.glmm(formula = formula, data = data, family = family,
+                               sp = sp, site = site, 
+                               random.effects = random.effects, REML = REML, 
+                               s2.init = s2.init, B.init = B.init, reltol = reltol, 
+                               maxit = maxit, tol.pql = tol.pql, maxit.pql = maxit.pql, 
+                               verbose = verbose, cpp = cpp, optimizer = optimizer)
+    }
+    if (family == "binomial") {
+      if (is.null(s2.init)) s2.init <- 0.25
+      if(!is.null(Ntrials)) {
+        resp <- all.vars(update(formula, .~0)) 
+        formula_glm <- update.formula(formula, as.formula(paste0("cbind(", resp, ", Ntrials - ", resp ,") ~ .")))
+      }
+      z <- communityPGLMM.glmm(formula = formula_glm, data = data, family = family,
                                sp = sp, site = site, 
                                random.effects = random.effects, REML = REML, 
                                s2.init = s2.init, B.init = B.init, reltol = reltol, 
@@ -953,8 +966,8 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
       pcprior <- list(prec = list(prior="pc.prec", param = c(3*sdres,0.01)))
     } else {
       if(family == "binomial") {
-        lmod <- glm(formula, data = data, family = "binomial")
-        sdres <- sd(lmod$y - lmod$fitted.values)
+        # lmod <- glm(formula, data = data, family = "binomial")
+        # sdres <- sd(lmod$y - lmod$fitted.values)
         pcprior <- list(prec = list(prior="pc.prec", param = c(1, 0.1)))
       } else {
         warning("pc.prior.auto not yet implemented for this family. switching to default INLA prior...")

--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -1133,7 +1133,7 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
   if(grepl("zeroinflated", family)) {
     zeroinlated_param <- 1/variances[1]
     variances <- variances[-1]
-    zeroinflated_param.ci <- 1/variances.ci[1, ]
+    zeroinflated_param.ci <- rev(1/variances.ci[1, ])
     variances.ci <- variances.ci[-1, ]
   } else {
     zeroinlated_param <- NULL

--- a/tests/testthat/test-pglmm.R
+++ b/tests/testthat/test-pglmm.R
@@ -68,15 +68,30 @@ test_that("ignore these tests when on CRAN since they are time consuming", {
   if(requireNamespace("INLA", quietly = TRUE)){
     test1_gaussian_bayes = phyr::communityPGLMM(freq ~ 1 + shade + (1 | sp__) + (1 | 
                                                                                    site) + (1 | sp__@site), dat, tree = phylotree, bayes = TRUE,
-                                                default.prior = "pc.prior.auto")
+                                                prior = "pc.prior.auto")
     
     test1_binomial_bayes = phyr::communityPGLMM(pa ~ 1 + shade + (1 | sp__) + (1 | site) + 
                                                   (1 | sp__@site), dat, tree = phylotree, ML.init = FALSE, bayes = TRUE,
-                                                family = "binomial", default.prior = "uninformative")
+                                                family = "binomial", prior = "pc.prior.auto")
     
     test1_poisson_bayes = phyr::communityPGLMM(freq ~ 1 + shade + (1 | sp__) + (1 | site) + 
                                                  (1 | sp__@site), dat, tree = phylotree, bayes = TRUE, ML.init = FALSE, 
-                                               family = "poisson", default.prior = "pc.prior",
+                                               family = "poisson", prior = "pc.prior.auto",
+                                               prior_alpha = 0.01, prior_mu = 1)
+    
+    test2_binomial_bayes = phyr::communityPGLMM(freq ~ 1 + shade + (1 | sp__) + (1 | site) + (1 | sp__@site), 
+                                               dat, tree = phylotree, family = 'binomial', add.obs.re = F, bayes = TRUE,
+                                               Ntrials = dat$freq + dat$freq2, ML.init = FALSE,
+                                               prior = "pc.prior.auto")
+    
+    test2_binomial_bayes_zi = phyr::communityPGLMM(freq ~ 1 + shade + (1 | sp__) + (1 | site) + (1 | sp__@site), 
+                                                  dat, tree = phylotree, family = 'zeroinflated.binomial', add.obs.re = F, bayes = TRUE,
+                                                  Ntrials = dat$freq + dat$freq2, ML.init = FALSE,
+                                                  prior = "pc.prior.auto")
+    
+    test2_poisson_bayes_zi = phyr::communityPGLMM(freq ~ 1 + shade + (1 | sp__) + (1 | site) + 
+                                                 (1 | sp__@site), dat, tree = phylotree, bayes = TRUE, ML.init = FALSE, 
+                                               family = "zeroinflated.poisson", prior = "pc.prior.auto",
                                                prior_alpha = 0.01, prior_mu = 1)
     
     ## try a 'overdispersed' Poisson (e.g. add row random effect to account for


### PR DESCRIPTION
Okay, I added support for an Ntrials parameter in the Bayesian version, which can be used in the binomial model. You can use it like this: 

```
phyr::communityPGLMM(freq ~ 1 + shade + (1 | sp__) + (1 | site) + (1 | sp__@site), 
                                               dat, tree = phylotree, family = 'binomial', add.obs.re = F, bayes = TRUE,
                                               Ntrials = dat$freq + dat$freq2, ML.init = FALSE,
                                               prior = "pc.prior.auto")
```

This was easier than trying to parse the formula for the cbind(success, failure) response and then work out how to get that into INLA.. I might try and work on this later, but for now this way works.

While I was at it I also added two new families: "zeroinflated.binomial" and "zeroinflated.poisson", which are zero inflated versions of binomial and poisson. They just add a zero inflation parameter, which estimates the probability that an observation is zero. The rest of the model parameters are then applied only to the non-zero part. See `INLA::inla.doc("zeroinflatedpoisson")` for details. I've implemented Type 1 zero inflation.
