### PR TITLE
Bayesian p-values and code deduplication

### DIFF
--- a/R/pglmm-utils.R
+++ b/R/pglmm-utils.R
@@ -1062,9 +1062,12 @@ fitted.communityPGLMM <- function(object, ...){
 #' @export
 fixef.communityPGLMM <- function(object, ...) {
   if (object$bayes) {
+
+    in_interval <- function(x, y1, y2){ y1 <= x & x <= y2 }
+
     coef <- data.frame(Value = object$B, lower.CI = object$B.ci[, 1], upper.CI = object$B.ci[, 2],
                        Pvalue = ifelse(apply(object$B.ci, 1, function(y)
-                         findInterval(0, y[1], y[2])) == 0,
+                         in_interval(0, y[1], y[2])) == FALSE,
                          0.04, 0.6))
   } else {
     coef <- data.frame(Value = object$B, Std.Error = object$B.se, 

--- a/R/pglmm-utils.R
+++ b/R/pglmm-utils.R
@@ -893,13 +893,10 @@ summary.communityPGLMM <- function(object, digits = max(3, getOption("digits") -
   print(w, digits = digits)
   
   cat("\nFixed effects:\n")
+  coef <- fixef.communityPGLMM(x)
   if(x$bayes) {
-    coef <- data.frame(Value = x$B, lower.CI = x$B.ci[ , 1], upper.CI = x$B.ci[ , 2], 
-                       Pvalue = ifelse(apply(x$B.ci, 1, function(y) findInterval(0, y[1], y[2])) == 0,
-                                       0.04, 0.6))
     printCoefmat(coef, P.values = FALSE, has.Pvalue = TRUE)
   } else {
-    coef <- data.frame(Value = x$B, Std.Error = x$B.se, Zscore = x$B.zscore, Pvalue = x$B.pvalue)
     printCoefmat(coef, P.values = TRUE, has.Pvalue = TRUE)
   }
   cat("\n")


### PR DESCRIPTION
Hello!
First of all, I would like to thank you for the great package!

Trying to fit some models to my data I noticed, that `fixef` on Bayesian PGLMMs returns a data.frame, where the last column is `Pvalue`. As I understand from the source code, Pvalue should be 0.6 if the credible interval for a particular predictor includes zero, and 0.04 if it does not.
However, `findInterval` function that you use doesn't return the correct result.
For example, `ifelse(findInterval(0, -5, -4) == 0, 0.04, 0.6)` will return 0.6, while the credible interval is [-5, -4].

This commit will fix the problem.
As a side effect, I removed duplicated code for `fixef` in `summary.communityPGLMM`.

With best regards,
Vladimir