### PR TITLE
Fixed memory error in rcond()

### DIFF
--- a/R/cor_phylo.R
+++ b/R/cor_phylo.R
@@ -773,7 +773,9 @@ sim_cor_phylo_variates <- function(n, Rs, d, M, X_means, X_sds, U_means, U_sds, 
 #'     \url{https://nlopt.readthedocs.io/en/latest/NLopt_Reference/#return-values}.}
 #'   \item{`rcond_vals`}{Reciprocal condition numbers for two matrices inside
 #'     the log likelihood function. These are provided to potentially help guide
-#'     the changing of the `rcond_threshold` parameter.}
+#'     the changing of the `rcond_threshold` parameter. 
+#'     If they are listed as `NaN`, then one or more of the matrices contains
+#'     `NA` before being passed through the `rcond` function.}
 #'   \item{`bootstrap`}{A list of bootstrap output, which is simply `list()` if
 #'     `boot = 0`. If `boot > 0`, then the list contains fields for 
 #'     estimates of correlations (`corrs`), phylogenetic signals (`d`),
@@ -791,48 +793,48 @@ sim_cor_phylo_variates <- function(n, Rs, d, M, X_means, X_sds, U_means, U_sds, 
 #'
 #' @examples
 #' 
+#' 
+#' ## Simple example using data without correlations or phylogenetic
+#' ## signal. This illustrates the structure of the input data.
+#' 
+#' set.seed(10)
+#' phy <- ape::rcoal(10, tip.label = 1:10)
+#' data_df <- data.frame(
+#'     species = phy$tip.label,
+#'     # variates:
+#'     par1 = rnorm(10),
+#'     par2 = rnorm(10),
+#'     par3 = rnorm(10),
+#'     # covariate for par2:
+#'     cov2 = rnorm(10, mean = 10, sd = 4),
+#'     # measurement error for par1 and par2, respectively:
+#'     se1 = 0.2,
+#'     se2 = 0.4
+#' )
+#' data_df$par2 <- data_df$par2 + 0.5 * data_df$cov2
+#' 
+#' 
+#' cp <- cor_phylo(variates = ~ par1 + par2 + par3,
+#'                 covariates = list(par2 ~ cov2),
+#'                 meas_errors = list(par1 ~ se1, par2 ~ se2),
+#'                 species = ~ species,
+#'                 phy = phy,
+#'                 data = data_df)
+#' 
+#' # If you've already created matrices/lists...
+#' X <- as.matrix(data_df[,c("par1", "par2", "par3")])
+#' U <- list(par2 = cbind(cov2 = data_df$cov2))
+#' M <- cbind(par1 = data_df$se1, par2 = data_df$se2)
+#' 
+#' # ... you can also use those directly
+#' # (notice that I'm inputting an object for `species`
+#' # bc I ommitted `data`):
+#' cp2 <- cor_phylo(variates = X, species = data_df$species,
+#'                  phy = phy, covariates = U,
+#'                  meas_errors = M)
+#' 
+#' 
 #' \donttest{
-#' # 
-#' # ## Simple example using data without correlations or phylogenetic
-#' # ## signal. This illustrates the structure of the input data.
-#' # 
-#' # set.seed(10)
-#' # phy <- ape::rcoal(10, tip.label = 1:10)
-#' # data_df <- data.frame(
-#' #     species = phy$tip.label,
-#' #     # variates:
-#' #     par1 = rnorm(10),
-#' #     par2 = rnorm(10),
-#' #     par3 = rnorm(10),
-#' #     # covariate for par2:
-#' #     cov2 = rnorm(10, mean = 10, sd = 4),
-#' #     # measurement error for par1 and par2, respectively:
-#' #     se1 = 0.2,
-#' #     se2 = 0.4
-#' # )
-#' # data_df$par2 <- data_df$par2 + 0.5 * data_df$cov2
-#' # 
-#' # 
-#' # # cor_phylo(variates = ~ par1 + par2 + par3,
-#' # #           covariates = list(par2 ~ cov2),
-#' # #           meas_errors = list(par1 ~ se1, par2 ~ se2),
-#' # #           species = ~ species,
-#' # #           phy = phy,
-#' # #           data = data_df)
-#' # 
-#' # # If you've already created matrices/lists...
-#' # X <- as.matrix(data_df[,c("par1", "par2", "par3")])
-#' # U <- list(par2 = cbind(cov2 = data_df$cov2))
-#' # M <- cbind(par1 = data_df$se1, par2 = data_df$se2)
-#' # 
-#' # # ... you can also use those directly
-#' # # (notice that I'm inputting an object for `species`
-#' # # bc I ommitted `data`):
-#' # # cor_phylo(variates = X, species = data_df$species,
-#' # #           phy = phy, covariates = U,
-#' # #           meas_errors = M)
-#' # 
-#' # 
 #' # 
 #' # 
 #' # ## Simulation example for the correlation between two variables. The example

--- a/man/cor_phylo.Rd
+++ b/man/cor_phylo.Rd
@@ -186,7 +186,9 @@ For more information on the nlopt return codes, see
 \url{https://nlopt.readthedocs.io/en/latest/NLopt_Reference/#return-values}.}
 \item{\code{rcond_vals}}{Reciprocal condition numbers for two matrices inside
 the log likelihood function. These are provided to potentially help guide
-the changing of the \code{rcond_threshold} parameter.}
+the changing of the \code{rcond_threshold} parameter.
+If they are listed as \code{NaN}, then one or more of the matrices contains
+\code{NA} before being passed through the \code{rcond} function.}
 \item{\code{bootstrap}}{A list of bootstrap output, which is simply \code{list()} if
 \code{boot = 0}. If \code{boot > 0}, then the list contains fields for
 estimates of correlations (\code{corrs}), phylogenetic signals (\code{d}),
@@ -258,48 +260,48 @@ extends in the obvious way to more than two variates.
 
 \examples{
 
+
+## Simple example using data without correlations or phylogenetic
+## signal. This illustrates the structure of the input data.
+
+set.seed(10)
+phy <- ape::rcoal(10, tip.label = 1:10)
+data_df <- data.frame(
+    species = phy$tip.label,
+    # variates:
+    par1 = rnorm(10),
+    par2 = rnorm(10),
+    par3 = rnorm(10),
+    # covariate for par2:
+    cov2 = rnorm(10, mean = 10, sd = 4),
+    # measurement error for par1 and par2, respectively:
+    se1 = 0.2,
+    se2 = 0.4
+)
+data_df$par2 <- data_df$par2 + 0.5 * data_df$cov2
+
+
+cp <- cor_phylo(variates = ~ par1 + par2 + par3,
+                covariates = list(par2 ~ cov2),
+                meas_errors = list(par1 ~ se1, par2 ~ se2),
+                species = ~ species,
+                phy = phy,
+                data = data_df)
+
+# If you've already created matrices/lists...
+X <- as.matrix(data_df[,c("par1", "par2", "par3")])
+U <- list(par2 = cbind(cov2 = data_df$cov2))
+M <- cbind(par1 = data_df$se1, par2 = data_df$se2)
+
+# ... you can also use those directly
+# (notice that I'm inputting an object for `species`
+# bc I ommitted `data`):
+cp2 <- cor_phylo(variates = X, species = data_df$species,
+                 phy = phy, covariates = U,
+                 meas_errors = M)
+
+
 \donttest{
-# 
-# ## Simple example using data without correlations or phylogenetic
-# ## signal. This illustrates the structure of the input data.
-# 
-# set.seed(10)
-# phy <- ape::rcoal(10, tip.label = 1:10)
-# data_df <- data.frame(
-#     species = phy$tip.label,
-#     # variates:
-#     par1 = rnorm(10),
-#     par2 = rnorm(10),
-#     par3 = rnorm(10),
-#     # covariate for par2:
-#     cov2 = rnorm(10, mean = 10, sd = 4),
-#     # measurement error for par1 and par2, respectively:
-#     se1 = 0.2,
-#     se2 = 0.4
-# )
-# data_df$par2 <- data_df$par2 + 0.5 * data_df$cov2
-# 
-# 
-# # cor_phylo(variates = ~ par1 + par2 + par3,
-# #           covariates = list(par2 ~ cov2),
-# #           meas_errors = list(par1 ~ se1, par2 ~ se2),
-# #           species = ~ species,
-# #           phy = phy,
-# #           data = data_df)
-# 
-# # If you've already created matrices/lists...
-# X <- as.matrix(data_df[,c("par1", "par2", "par3")])
-# U <- list(par2 = cbind(cov2 = data_df$cov2))
-# M <- cbind(par1 = data_df$se1, par2 = data_df$se2)
-# 
-# # ... you can also use those directly
-# # (notice that I'm inputting an object for `species`
-# # bc I ommitted `data`):
-# # cor_phylo(variates = X, species = data_df$species,
-# #           phy = phy, covariates = U,
-# #           meas_errors = M)
-# 
-# 
 # 
 # 
 # ## Simulation example for the correlation between two variables. The example

--- a/src/cor_phylo.cpp
+++ b/src/cor_phylo.cpp
@@ -71,12 +71,14 @@ double cor_phylo_LL(NumericVector par,
   arma::mat C = make_C(n, p, tau, d, Vphy, R);
   
   arma::mat V = make_V(C, MM);
+  if (V.has_nan() || V.has_inf()) return MAX_RETURN;
   double rcond_dbl = 0;
   rcond_dbl = arma::rcond(V);
   if (!arma::is_finite(rcond_dbl) || rcond_dbl < rcond_threshold) return MAX_RETURN;
   
   arma::mat iV = arma::inv(V);
   arma::mat denom = UU.t() * iV * UU;
+  if (denom.has_nan() || denom.has_inf()) return MAX_RETURN;
   rcond_dbl = arma::rcond(denom);
   if (!arma::is_finite(rcond_dbl) || rcond_dbl < rcond_threshold) return MAX_RETURN;
   
@@ -149,12 +151,20 @@ std::vector<double> return_rcond_vals(XPtr<LogLikInfo> ll_info) {
   
   arma::mat V = make_V(C, MM);
   double rcond_dbl = 0;
-  rcond_dbl = arma::rcond(V);
+  if (V.has_nan() || V.has_inf()) {
+    rcond_dbl = arma::datum::nan;
+  } else {
+    rcond_dbl = arma::rcond(V);
+  }
   rconds_out[0] = rcond_dbl;
   
   arma::mat iV = arma::inv(V);
   arma::mat denom = UU.t() * iV * UU;
-  rcond_dbl = arma::rcond(denom);
+  if (denom.has_nan() || denom.has_inf()) {
+    rcond_dbl = arma::datum::nan;
+  } else {
+    rcond_dbl = arma::rcond(denom);
+  }
   rconds_out[1] = rcond_dbl;
   
   return rconds_out;


### PR DESCRIPTION
Valgrind (via r-hub) now runs the cor_phylo examples without errors, so they are uncommented in this version.