### PR TITLE
fixes #73, issue with translating formula

### DIFF
--- a/R/pglmm.R
+++ b/R/pglmm.R
@@ -990,8 +990,10 @@ communityPGLMM.bayes <- function(formula, data = list(), family = "gaussian",
     Y <- Y[, 1] # success
     # update formula
     left_side = all.vars(update(formula, .~0))[1]
-    formula_bayes = as.formula(gsub(pattern = "^(cbind[(].*[)])",
-                                    replacement = left_side, x = deparse(formula)))
+    formula_bayes <- formula
+    formula_bayes[[2]] <- as.name(left_side)
+    # formula_bayes = as.formula(gsub(pattern = "^(cbind[(].*[)])",
+    #                                 replacement = left_side, x = deparse(formula)))
   } else {
     formula_bayes = formula
     Ntrials = NULL


### PR DESCRIPTION
Something was going wrong with the `gsub` replacing the `cbind` call. This PR fixes that by instead just directly replacing the second element of the formula (which corresponds to the LHS), with the correct symbol. It works for the example bug that prompted issue #73 . And I think it should work in general, but please give it a look over @daijiang. Thanks!