### PR TITLE
Use futures for cor_phylo bootstrap multithreading

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     latticeExtra,
     tidyr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.1
 LinkingTo:
     Rcpp, RcppArmadillo
 Suggests: 
@@ -52,7 +52,8 @@ Suggests:
     ggplot2,
     ggridges,
     DHARMa,
-    rr2
+    rr2,
+    future.apply
 VignetteBuilder: knitr
 URL: https://daijiang.github.io/phyr/, https://github.com/daijiang/phyr/
 BugReports: https://github.com/daijiang/phyr/issues

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -16,13 +16,29 @@ cor_phylo_LL <- function(par, XX, UU, MM, Vphy, tau, REML, constrain_d, lower_d,
 #' @inheritParams cor_phylo
 #' @param method the `method` input to `cor_phylo`.
 #' 
-#' @return a list containing output information, to later be coerced to a `cor_phylo`
-#'   object by the `cor_phylo` function.
+#' @return a list containing output information, to later be coerced to a 
+#'   `cor_phylo` object by the `cor_phylo` function.
 #' @noRd
 #' @name cor_phylo_cpp
 #' 
-cor_phylo_cpp <- function(X, U, M, Vphy_, REML, constrain_d, lower_d, verbose, rcond_threshold, rel_tol, max_iter, method, no_corr, boot, keep_boots, sann) {
-    .Call(`_phyr_cor_phylo_cpp`, X, U, M, Vphy_, REML, constrain_d, lower_d, verbose, rcond_threshold, rel_tol, max_iter, method, no_corr, boot, keep_boots, sann)
+cor_phylo_cpp <- function(X, U, M, Vphy, REML, constrain_d, lower_d, verbose, rcond_threshold, rel_tol, max_iter, method, no_corr, sann) {
+    .Call(`_phyr_cor_phylo_cpp`, X, U, M, Vphy, REML, constrain_d, lower_d, verbose, rcond_threshold, rel_tol, max_iter, method, no_corr, sann)
+}
+
+#' Inner function to do one bootstrapping rep.
+#' 
+#' The arguments before `X` are needed in this function but not in
+#' `cor_phylo_cpp`, while the arguments starting at `X` are all those required
+#' in `cor_phylo_cpp`.
+#'
+#' @noRd
+#' 
+one_boot_cpp <- function(rnd_vec, min_par, B, d, keep_boots, X, U, M, Vphy, REML, constrain_d, lower_d, verbose, rcond_threshold, rel_tol, max_iter, method, no_corr, sann) {
+    .Call(`_phyr_one_boot_cpp`, rnd_vec, min_par, B, d, keep_boots, X, U, M, Vphy, REML, constrain_d, lower_d, verbose, rcond_threshold, rel_tol, max_iter, method, no_corr, sann)
+}
+
+organize_boots <- function(orig_list) {
+    .Call(`_phyr_organize_boots`, orig_list)
 }
 
 set_seed <- function(seed) {

--- a/man/cor_phylo.Rd
+++ b/man/cor_phylo.Rd
@@ -125,15 +125,19 @@ Increasing this threshold makes the optimization process more strongly
 and with estimates that are nonsensical.
 Defaults to \code{1e-10}.}
 
-\item{boot}{Number of parametric bootstrap replicates. Defaults to \code{0}.}
+\item{boot}{Number of parametric bootstrap replicates.
+Bootstrapping can be run in parallel if \code{future.apply} is
+installed and if \code{future::plan(...)} is run before the call
+to \code{cor_phylo}. See the documentation for \code{future::plan}
+for the various options. Defaults to \code{0}.}
 
-\item{keep_boots}{Character specifying when to output data (indices, convergence codes,
+\item{keep_boots}{Character specifying when to output data (convergence codes
 and simulated variate data) from bootstrap replicates.
 This is useful for troubleshooting when one or more bootstrap replicates
 fails to converge or outputs ridiculous results.
 Setting this to \code{"all"} keeps all \code{boot} parameter sets,
-\code{"fail"} keeps parameter sets from replicates that failed to converge,
-and \code{"none"} keeps no parameter sets.
+\code{"fail"} keeps sets from replicates that failed to converge,
+and \code{"none"} keeps no sets.
 Defaults to \code{"fail"}.}
 
 \item{mod}{\code{cor_phylo} object that was run with the \code{boot} argument > 0.}
@@ -192,14 +196,12 @@ If they are listed as \code{NaN}, then one or more of the matrices contains
 \item{\code{bootstrap}}{A list of bootstrap output, which is simply \code{list()} if
 \code{boot = 0}. If \code{boot > 0}, then the list contains fields for
 estimates of correlations (\code{corrs}), phylogenetic signals (\code{d}),
-coefficients (\code{B0}), and coefficient covariances (\code{B_cov}).
-It also contains the following information about the bootstrap replicates:
-a vector of indices relating each set of information to the bootstrapped
-estimates (\code{inds}),
-convergence codes (\code{convcodes}), and
-matrices of the bootstrapped parameters in the order they appear in the input
-argument (\code{mats});
-these three fields will be empty if \code{keep_boots == "none"}.
+coefficients (\code{B0}), and coefficient covariances (\code{B_cov}), plus
+a vector of convergence codes (\code{convcodes}).
+Depending on the value of \code{keep_boots}, this list may also contain a
+list of matrices containing the bootstrapped parameter sets (\code{mats}).
+If \code{keep_boots == "fail"}, then \code{mats} will contain a \verb{<0 x 0 matrix>}
+for rep(s) that succeed.
 To view bootstrapped confidence intervals, use \code{boot_ci}.}
 
 \code{boot_ci} returns a list of confidence intervals with the following fields:
@@ -228,11 +230,11 @@ independent variables affecting each variate.
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{boot_ci}: returns bootstrapped confidence intervals from a \code{cor_phylo} object
+\item \code{boot_ci(cor_phylo)}: returns bootstrapped confidence intervals from a \code{cor_phylo} object
 
-\item \code{print}: prints \code{cor_phylo} objects
+\item \code{print(cor_phylo)}: prints \code{cor_phylo} objects
+
 }}
-
 \section{Walkthrough}{
 
 For the case of two variables, the function estimates parameters for the model of

--- a/man/refit_boots.Rd
+++ b/man/refit_boots.Rd
@@ -17,6 +17,10 @@ This is useful if you want to try refitting only a portion of bootstrap
 replicates.
 By passing \code{NULL}, it refits all bootstrap replicates present in
 \code{cp_obj$bootstrap$mats}.
+If, in the original call to \code{cor_phylo}, \code{keep_boots} was set to
+\code{"fail"}, then any successful replicates cannot be refit here.
+An error will be thrown if you use \code{inds} to request a successful rep
+to be refit when \code{keep_boots} was set to \code{"fail"}.
 Any bootstrap replicates not present in \code{inds} will have \code{NA} in the output
 object.
 Defaults to \code{NULL}.}
@@ -34,15 +38,15 @@ A \code{cp_refits} object, which is a list of \code{cor_phylo} objects
 corresponding to each matrix in \verb{<original cor_phylo object>$bootstrap$mats}.
 }
 \description{
-This function is to be called on a \code{cor_phylo} object if when one or more bootstrap
+This function is to be called on a \code{cor_phylo} object if one or more bootstrap
 replicates fail to converge.
 It allows the user to change parameters for the optimizer to get it to converge.
 One or more of the resulting \code{cp_refits} object(s) can be supplied to
 \code{boot_ci} along with the original \code{cor_phylo} object to calculate confidence
 intervals from only bootstrap replicates that converged.
 }
-\section{Methods (by generic)}{
+\section{Functions}{
 \itemize{
-\item \code{print}: prints \code{cp_refits} objects
-}}
+\item \code{print(cp_refits)}: prints \code{cp_refits} objects
 
+}}

--- a/man/simulate.communityPGLMM.Rd
+++ b/man/simulate.communityPGLMM.Rd
@@ -18,7 +18,8 @@
 If \code{NULL}, include all random effects and the conditional modes of those random effects will be included in the deterministic part of the simulation (i.e Xb + Zu);
 if \code{NA} or \code{~0}, include no random effects and new values will be chosen for each group based on the estimated random-effects variances (i.e. Xb + Zu * u_random).}
 
-\item{...}{optional additional arguments: none are used at present.}
+\item{...}{optional additional arguments (none are used in
+    \code{.simulateFormula})}
 }
 \description{
 Note that this function currently only works for model fit with \code{bayes = TRUE}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -33,15 +33,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // cor_phylo_cpp
-List cor_phylo_cpp(const arma::mat& X, const std::vector<arma::mat>& U, const arma::mat& M, const arma::mat& Vphy_, const bool& REML, const bool& constrain_d, const double& lower_d, const bool& verbose, const double& rcond_threshold, const double& rel_tol, const int& max_iter, const std::string& method, const bool& no_corr, const uint_fast32_t& boot, const std::string& keep_boots, const std::vector<double>& sann);
-RcppExport SEXP _phyr_cor_phylo_cpp(SEXP XSEXP, SEXP USEXP, SEXP MSEXP, SEXP Vphy_SEXP, SEXP REMLSEXP, SEXP constrain_dSEXP, SEXP lower_dSEXP, SEXP verboseSEXP, SEXP rcond_thresholdSEXP, SEXP rel_tolSEXP, SEXP max_iterSEXP, SEXP methodSEXP, SEXP no_corrSEXP, SEXP bootSEXP, SEXP keep_bootsSEXP, SEXP sannSEXP) {
+List cor_phylo_cpp(const arma::mat& X, const std::vector<arma::mat>& U, const arma::mat& M, const arma::mat& Vphy, const bool& REML, const bool& constrain_d, const double& lower_d, const bool& verbose, const double& rcond_threshold, const double& rel_tol, const int& max_iter, const std::string& method, const bool& no_corr, const std::vector<double>& sann);
+RcppExport SEXP _phyr_cor_phylo_cpp(SEXP XSEXP, SEXP USEXP, SEXP MSEXP, SEXP VphySEXP, SEXP REMLSEXP, SEXP constrain_dSEXP, SEXP lower_dSEXP, SEXP verboseSEXP, SEXP rcond_thresholdSEXP, SEXP rel_tolSEXP, SEXP max_iterSEXP, SEXP methodSEXP, SEXP no_corrSEXP, SEXP sannSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const arma::mat& >::type X(XSEXP);
     Rcpp::traits::input_parameter< const std::vector<arma::mat>& >::type U(USEXP);
     Rcpp::traits::input_parameter< const arma::mat& >::type M(MSEXP);
-    Rcpp::traits::input_parameter< const arma::mat& >::type Vphy_(Vphy_SEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type Vphy(VphySEXP);
     Rcpp::traits::input_parameter< const bool& >::type REML(REMLSEXP);
     Rcpp::traits::input_parameter< const bool& >::type constrain_d(constrain_dSEXP);
     Rcpp::traits::input_parameter< const double& >::type lower_d(lower_dSEXP);
@@ -51,10 +51,48 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int& >::type max_iter(max_iterSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type method(methodSEXP);
     Rcpp::traits::input_parameter< const bool& >::type no_corr(no_corrSEXP);
-    Rcpp::traits::input_parameter< const uint_fast32_t& >::type boot(bootSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type keep_boots(keep_bootsSEXP);
     Rcpp::traits::input_parameter< const std::vector<double>& >::type sann(sannSEXP);
-    rcpp_result_gen = Rcpp::wrap(cor_phylo_cpp(X, U, M, Vphy_, REML, constrain_d, lower_d, verbose, rcond_threshold, rel_tol, max_iter, method, no_corr, boot, keep_boots, sann));
+    rcpp_result_gen = Rcpp::wrap(cor_phylo_cpp(X, U, M, Vphy, REML, constrain_d, lower_d, verbose, rcond_threshold, rel_tol, max_iter, method, no_corr, sann));
+    return rcpp_result_gen;
+END_RCPP
+}
+// one_boot_cpp
+List one_boot_cpp(const arma::vec& rnd_vec, const arma::vec& min_par, const arma::mat& B, const arma::vec& d, const std::string& keep_boots, const arma::mat& X, const std::vector<arma::mat>& U, const arma::mat& M, const arma::mat& Vphy, const bool& REML, const bool& constrain_d, const double& lower_d, const bool& verbose, const double& rcond_threshold, const double& rel_tol, const int& max_iter, const std::string& method, const bool& no_corr, const std::vector<double>& sann);
+RcppExport SEXP _phyr_one_boot_cpp(SEXP rnd_vecSEXP, SEXP min_parSEXP, SEXP BSEXP, SEXP dSEXP, SEXP keep_bootsSEXP, SEXP XSEXP, SEXP USEXP, SEXP MSEXP, SEXP VphySEXP, SEXP REMLSEXP, SEXP constrain_dSEXP, SEXP lower_dSEXP, SEXP verboseSEXP, SEXP rcond_thresholdSEXP, SEXP rel_tolSEXP, SEXP max_iterSEXP, SEXP methodSEXP, SEXP no_corrSEXP, SEXP sannSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const arma::vec& >::type rnd_vec(rnd_vecSEXP);
+    Rcpp::traits::input_parameter< const arma::vec& >::type min_par(min_parSEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type B(BSEXP);
+    Rcpp::traits::input_parameter< const arma::vec& >::type d(dSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type keep_boots(keep_bootsSEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type X(XSEXP);
+    Rcpp::traits::input_parameter< const std::vector<arma::mat>& >::type U(USEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type M(MSEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type Vphy(VphySEXP);
+    Rcpp::traits::input_parameter< const bool& >::type REML(REMLSEXP);
+    Rcpp::traits::input_parameter< const bool& >::type constrain_d(constrain_dSEXP);
+    Rcpp::traits::input_parameter< const double& >::type lower_d(lower_dSEXP);
+    Rcpp::traits::input_parameter< const bool& >::type verbose(verboseSEXP);
+    Rcpp::traits::input_parameter< const double& >::type rcond_threshold(rcond_thresholdSEXP);
+    Rcpp::traits::input_parameter< const double& >::type rel_tol(rel_tolSEXP);
+    Rcpp::traits::input_parameter< const int& >::type max_iter(max_iterSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type method(methodSEXP);
+    Rcpp::traits::input_parameter< const bool& >::type no_corr(no_corrSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type sann(sannSEXP);
+    rcpp_result_gen = Rcpp::wrap(one_boot_cpp(rnd_vec, min_par, B, d, keep_boots, X, U, M, Vphy, REML, constrain_d, lower_d, verbose, rcond_threshold, rel_tol, max_iter, method, no_corr, sann));
+    return rcpp_result_gen;
+END_RCPP
+}
+// organize_boots
+List organize_boots(List orig_list);
+RcppExport SEXP _phyr_organize_boots(SEXP orig_listSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< List >::type orig_list(orig_listSEXP);
+    rcpp_result_gen = Rcpp::wrap(organize_boots(orig_list));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -334,7 +372,9 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_phyr_cor_phylo_LL", (DL_FUNC) &_phyr_cor_phylo_LL, 11},
-    {"_phyr_cor_phylo_cpp", (DL_FUNC) &_phyr_cor_phylo_cpp, 16},
+    {"_phyr_cor_phylo_cpp", (DL_FUNC) &_phyr_cor_phylo_cpp, 14},
+    {"_phyr_one_boot_cpp", (DL_FUNC) &_phyr_one_boot_cpp, 19},
+    {"_phyr_organize_boots", (DL_FUNC) &_phyr_organize_boots, 1},
     {"_phyr_set_seed", (DL_FUNC) &_phyr_set_seed, 1},
     {"_phyr_predict_cpp", (DL_FUNC) &_phyr_predict_cpp, 4},
     {"_phyr_pcd2_loop", (DL_FUNC) &_phyr_pcd2_loop, 7},


### PR DESCRIPTION
Bootstrapping in `cor_phylo` can now be done using the `future.apply` package. Using futures is done as follows:

```r
library(future.apply)
library(phyr)
## change this depending on your system:
plan(multisession)
# now run cor_phylo as desired, and bootstrapping will use futures:
cp <- cor_phylo(..., boot = 100)
```

If the package `future.apply` is not installed, bootstrapping is done serially.