### PR TITLE
Switch from deprecated arma::is_finite to std::isfinite

### DIFF
--- a/src/cor_phylo.cpp
+++ b/src/cor_phylo.cpp
@@ -71,13 +71,13 @@ double cor_phylo_LL(NumericVector par,
   if (V.has_nan() || V.has_inf()) return MAX_RETURN;
   double rcond_dbl = 0;
   rcond_dbl = arma::rcond(V);
-  if (!arma::is_finite(rcond_dbl) || rcond_dbl < rcond_threshold) return MAX_RETURN;
+  if (!std::isfinite(rcond_dbl) || rcond_dbl < rcond_threshold) return MAX_RETURN;
   
   arma::mat iV = arma::inv(V);
   arma::mat denom = UU.t() * iV * UU;
   if (denom.has_nan() || denom.has_inf()) return MAX_RETURN;
   rcond_dbl = arma::rcond(denom);
-  if (!arma::is_finite(rcond_dbl) || rcond_dbl < rcond_threshold) return MAX_RETURN;
+  if (!std::isfinite(rcond_dbl) || rcond_dbl < rcond_threshold) return MAX_RETURN;
   
   arma::mat num = UU.t() * iV * XX;
   arma::vec B0 = arma::solve(denom, num);
@@ -85,7 +85,7 @@ double cor_phylo_LL(NumericVector par,
   
   double logdetV, det_sign;
   arma::log_det(logdetV, det_sign, iV);
-  if (!arma::is_finite(logdetV)) return MAX_RETURN;
+  if (!std::isfinite(logdetV)) return MAX_RETURN;
   logdetV *= -1;
   
   double LL;


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard, which also means I can no-longer add the suppression of deprecation warnings (which used a macro before and now use a C++14 or later attribute). For most packages, adapting to it can be very simple, and yours is one of them -- in fact it is just three statements. In the patch below we simply update this as now required by Armadillo 15.0.x.  

Please see issues [#475](https://github.com/RcppCore/RcppArmadillo/issues/475) and below at the RcppArmadillo GitHub repo for context, and notably [#491](https://github.com/RcppCore/RcppArmadillo/issues/491) for this second wave of PRs and patches (following one for moving away from C++11, something your package does not need). It would be terrific if you could make an upload to CRAN 'soon' to remove the deprecation warning. Please do not hesitate to reach out if I can assist in any way or clarify matters.